### PR TITLE
Update Dockerfile and add wait-for-it.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ ENV CBMON_PATH $GOPATH/cb-dragonfly
 RUN cd $GOPATH/cb-dragonfly/pkg/manager/main;go build -o runMyapp;cp runMyapp $GOPATH/cb-dragonfly
 
 #ENTRYPOINT ["./runMyapp"]
+ENV DRAGONFLY_INFLUXDB_URL 127.0.0.1:8086
 ENTRYPOINT ["./wait-for-it-wrapper.sh"]
 
 EXPOSE 8094/udp 9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ ENV CBMON_PATH $GOPATH/cb-dragonfly
 
 RUN cd $GOPATH/cb-dragonfly/pkg/manager/main;go build -o runMyapp;cp runMyapp $GOPATH/cb-dragonfly
 
-ENTRYPOINT ["./runMyapp"]
+#ENTRYPOINT ["./runMyapp"]
+ENTRYPOINT ["./wait-for-it-wrapper.sh"]
 
 EXPOSE 8094/udp 9090

--- a/wait-for-it-wrapper.sh
+++ b/wait-for-it-wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+./wait-for-it.sh cb-dragonfly-influxdb:8086 -t 10 -- ./runMyapp

--- a/wait-for-it-wrapper.sh
+++ b/wait-for-it-wrapper.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./wait-for-it.sh cb-dragonfly-influxdb:8086 -t 10 -- ./runMyapp
+./wait-for-it.sh $DRAGONFLY_INFLUXDB_URL -t 10 -- ./runMyapp

--- a/wait-for-it-wrapper.sh
+++ b/wait-for-it-wrapper.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./wait-for-it.sh $DRAGONFLY_INFLUXDB_URL -t 10 -- ./runMyapp
+./wait-for-it.sh $DRAGONFLY_INFLUXDB_URL -t 20 -- ./runMyapp

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# https://github.com/vishnubob/wait-for-it
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
`Dockerfile` 을 이용하여 이미지를 만들고
`docker-compose.yaml` 을 작성하여 CB 시스템을 띄울 때

InfluxDB 가 아직 완전히 뜨지 않은 상태에서
`./runMyapp` 을 실행하면
`connect: connection refused` 가 떠서
Dragonfly 가 뜨지 못하고 죽는 문제가 있었습니다.

---

Docker Compose 에 `depends_on` 을 명시할 수 있기는 하지만
이것을 이용해도 컨테이너로 실행된 DB 서비스 (여기서는 InfluxDB) 가 완전히 ready 될 때까지 기다려 주지는 않습니다.

https://docs.docker.com/compose/startup-order/
> You can control the order of service startup and shutdown with the depends_on option. Compose always starts and stops containers in dependency order, where dependencies are determined by depends_on, links, volumes_from, and network_mode: "service:...".

> However, for startup Compose does not wait until a container is “ready” (whatever that means for your particular application) - only until it’s running. There’s a good reason for this.

> The problem of waiting for a database (for example) to be ready is really just a subset of a much larger problem of distributed systems. In production, your database could become unavailable or move hosts at any time. Your application needs to be resilient to these types of failures.

> To handle this, design your application to attempt to re-establish a connection to the database after a failure. If the application retries the connection, it can eventually connect to the database.

> The best solution is to perform this check in your application code, both at startup and whenever a connection is lost for any reason. However, if you don’t need this level of resilience, you can work around the problem with a wrapper script:

---

이에, Dragonfly repo 에 `wait-for-it.sh` 와 `wait-for-it-wrapper.sh` 를 추가하고 `Dockerfile` 을 수정하였습니다.
Dragonfly 컨테이너를 실행하면 `wait-for-it-wrapper.sh` 가 실행되며
`wait-for-it-wrapper.sh` 에 의해 `http://cb-dragonfly-influxdb:8086` 를 최대 10초 기다리며,
10초 전이라도 available 해지면 즉시 `./runMyapp` 을 실행합니다.
10초를 기다려도 available 해지지 않으면 timeout 처리하고 `./runMyapp` 을 실행합니다.

---

관련 테스트는 다음 방법으로 해 보실 수 있습니다.
```
$ git clone https://github.com/jihoon-seo/cb-deployer.git
$ cd cb-deployer
$ docker-compose up
```

---

Ref) @powerkimhub @seokho-son 