### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ If you have any difficulties in using CB-Dragonfly, please let us know.
                 export CBSTORE_ROOT=~/cb-dragonfly
                 export CBLOG_ROOT=~/cb-dragonfly
                 export CBMON_ROOT=~/cb-dragonfly
-                export SPIDER_URL=http://localhost:1024
                 
           - `$ source setup.env` (수정한 setup.env 반영)         
           - `$ go run pkg/manager/main/main.go` (실행)


### PR DESCRIPTION
README 에 `SPIDER_URL` 환경변수를 설정하는 내용이 있는데,
CB-Dragonfly repo 에서 `SPIDER_URL` 로 검색을 하면 결과가 나오지 않습니다.
지금은 사용되지 않는 환경변수 인 것 같습니다.
이 PR은 README 에서 관련 내용을 삭제하는 PR 입니다.
확인을 부탁드립니다.. ^^