### PR TITLE
Fix metaDB path

### DIFF
--- a/conf/log_conf.yaml
+++ b/conf/log_conf.yaml
@@ -8,7 +8,7 @@ cblog:
   loglevel: error # If loopcheck is true, You can set this online.
 
   ## true | false
-  logfile: false
+  logfile: true
 
 ## Config for File Output ##
 logfileinfo:

--- a/conf/store_conf.yaml
+++ b/conf/store_conf.yaml
@@ -6,7 +6,7 @@ storetype: NUTSDB
 #storetype: ETCD
 
 nutsdb:
-  dbpath: "meta_db/dat"
+  dbpath: "$CBSTORE_ROOT/meta_db/dat"
   segmentsize: 1048576  # 1048576 1024*1024 (1MB)
   #segmentsize: 10485760  # 10485760 10*1024*1024 (10MB)
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,8 +9,9 @@ services:
     image: cloudbaristaorg/cb-dragonfly:espresso-v0.1-kafka
     container_name: cb-dragonfly
     volumes:
-      - ./conf:/go/src/github.com/cloud-barista/cb-dragonfly/conf
-      - ./log:/go/src/github.com/cloud-barista/cb-dragonfly/log
+      - ./conf/:/go/src/github.com/cloud-barista/cb-dragonfly/conf/
+      - ./meta_db/:/go/src/github.com/cloud-barista/cb-dragonfly/meta_db/
+      - ./log/:/go/src/github.com/cloud-barista/cb-dragonfly/log/
     ports:
       - 9090:9090
       - 9999:9999


### PR DESCRIPTION
CC @powerkimhub 

- Resolves #73 
- [conf/store_conf.yaml](https://github.com/cloud-barista/cb-dragonfly/blob/master/conf/store_conf.yaml) 를 다음과 같이 수정
```diff
-   dbpath: "meta_db/dat"
+   dbpath: "$CBSTORE_ROOT/meta_db/dat"
```
- DF repo 의 docker-compose.yaml 에 volume mount 추가
- 로그 파일 기록 활성화