### PR TITLE
Kafka( err msg : "Local: time-out" ) 에러 로그 발생 지점 확인 및 에러 문구 변경

### DIFF
--- a/pkg/collector/aggregator.go
+++ b/pkg/collector/aggregator.go
@@ -29,7 +29,7 @@ func (a *Aggregator) AggregateMetric(kafkaConn *kafka.Consumer, topics []string)
 		stayConnCount += 1
 		msg, err := kafkaConn.ReadMessage(1 * time.Second)
 		if err != nil {
-			logrus.Debug(err)
+			logrus.Debug("From AggregateMetric, pre-topics conn based kafkaConn bring about above err : ", err)
 		}
 		if msg != nil {
 			msgTime := msg.Timestamp.Unix()


### PR DESCRIPTION
Kafka( err msg : "Local: time-out" ) 에러 로그 발생 지점 확인 및 에러 문구 변경
 - Collector의 Topic 재구독으로 인해 기존의 Topic Connection Time-out 에러 로그 발생
 - 기존 로직 동작에 영항을 미치지 않음
 - 에러 발생 지점 Tracking을 위해 에러 문구를 자세하게 변경