### PR TITLE
Update README.md for Go report card link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # CB-Dragonfly
 Cloud-Barista Integrated Monitoring Framework
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/cloud-barista/cb-dragonfly)](https://goreportcard.com/badge/github.com/cloud-barista/cb-dragonfly)
+[![Go Report Card](https://goreportcard.com/badge/github.com/cloud-barista/cb-dragonfly)](https://goreportcard.com/report/github.com/cloud-barista/cb-dragonfly)
 [![Build](https://img.shields.io/github/workflow/status/cloud-barista/cb-dragonfly/Build%20amd64%20container%20image)](https://github.com/cloud-barista/cb-dragonfly/actions?query=workflow%3A%22Build+amd64+container+image%22)
 [![Top Language](https://img.shields.io/github/languages/top/cloud-barista/cb-dragonfly)](https://github.com/cloud-barista/cb-dragonfly/search?l=go)
 [![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/cloud-barista/cb-dragonfly?label=go.mod)](https://github.com/cloud-barista/cb-dragonfly/blob/master/go.mod)


### PR DESCRIPTION
고리포트의 링크를 바르게 수정하였습니다.
https://goreportcard.com/report/github.com/cloud-barista/cb-dragonfly