### PR TITLE
CB-Dragonfly Bugfix

### DIFF
--- a/build-image.sh
+++ b/build-image.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 # CB-Dragonfly Image
-sudo docker build -t cloudbaristaorg/cb-dragonfly:0.7.0 . --no-cache
-sudo docker push cloudbaristaorg/cb-dragonfly:0.7.0
+sudo docker build -t cloudbaristaorg/cb-dragonfly:0.7.2 . --no-cache
+sudo docker push cloudbaristaorg/cb-dragonfly:0.7.2
 
 # MCIS Collector Image
 sudo docker build -t cloudbaristaorg/cb-dragonfly:0.7.0-mcis-collector -f Collector.MCIS.Dockerfile . --no-cache

--- a/helm/cb-dragonfly/Chart.yaml
+++ b/helm/cb-dragonfly/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: cb-dragonfly
 type: application
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.7.2
+appVersion: 0.7.2
 description: CB-Dragonfly Helm chart
 dependencies:
   - name: influxdb

--- a/helm/cb-dragonfly/templates/secret.yaml
+++ b/helm/cb-dragonfly/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: influxdb-auth
+type: Opaque
+data:
+  influxdb-user: Y2Jtb24= # cbmon
+  influxdb-password: cGFzc3dvcmQ= # password

--- a/helm/cb-dragonfly/values.yaml
+++ b/helm/cb-dragonfly/values.yaml
@@ -23,15 +23,12 @@ kapacitor:
   enabled: true
 #  nameOverride: "dragonfly-kapacitor"
   fullnameOverride: "cb-dragonfly-kapacitor"
-  envVars:
-    #KAPACITOR_INFLUXDB_0_URLS_0: http://cb-dragonfly-influxdb:8086
-    KAPACITOR_INFLUXDB_0_USERNAME: cbmon
-    KAPACITOR_INFLUXDB_0_PASSWORD: password
   persistence:
     enabled: false
     size: "8Gi"
     accessModes: "ReadWriteMany"
   influxURL: http://cb-dragonfly-influxdb:8086
+  existingSecret: influxdb-auth
   #  namespaceOverride: cloud-barista
 
 ## external : kafka

--- a/pkg/api/core/alert/client.go
+++ b/pkg/api/core/alert/client.go
@@ -27,7 +27,7 @@ func newClient() (*kclient.Client, error) {
 	}
 	kapacitorConfig := kclient.Config{
 		URL:                fmt.Sprintf("http://%s:%d", config.GetDefaultConfig().Kapacitor.EndpointUrl, kapacitorPort),
-		Timeout:            time.Duration(kapacitorTimeout),
+		Timeout:            kapacitorTimeout,
 		InsecureSkipVerify: true,
 	}
 	client, err := kclient.New(kapacitorConfig)

--- a/pkg/api/core/alert/event/event.go
+++ b/pkg/api/core/alert/event/event.go
@@ -43,7 +43,7 @@ func CreateEventLog(eventLog alerttypes.AlertEventLog) error {
 
 func ListEventLog(taskId string, logLevel string) ([]alerttypes.AlertEventLog, error) {
 	var eventLogArr []alerttypes.AlertEventLog
-	eventLogStr, err := cbstore.GetInstance().StoreGet(taskId)
+	eventLogStr, err := cbstore.GetInstance().StoreGet(fmt.Sprintf("%s/%s", types.EventLog, taskId))
 	if err != nil {
 		return []alerttypes.AlertEventLog{}, err
 	}

--- a/pkg/api/core/alert/eventhandler/event/slack/slack.go
+++ b/pkg/api/core/alert/eventhandler/event/slack/slack.go
@@ -74,7 +74,7 @@ func (s SlackHandler) UpdateEventHandler(name string, updateOpts types.AlertEven
 	// Set slack update options
 	options := map[string]interface{}{}
 	options["enabled"] = true
-	options["workspace"] = updateOpts.Name
+	options["workspace"] = name
 	options["url"] = updateOpts.Url
 	options["channel"] = updateOpts.Channel
 

--- a/pkg/api/core/alert/eventhandler/event/smtp/smtp.go
+++ b/pkg/api/core/alert/eventhandler/event/smtp/smtp.go
@@ -64,7 +64,7 @@ func (s SmtpHandler) UpdateEventHandler(name string, updateOpts types.AlertEvent
 	if err != nil {
 		return types.AlertEventHandler{}, err
 	}
-	return s.GetEventHandler(updateOpts.Name)
+	return s.GetEventHandler(name)
 }
 
 func (s SmtpHandler) DeleteEventHandler(name string) error {

--- a/pkg/api/core/metric/mcis/ondemand_metric.go
+++ b/pkg/api/core/metric/mcis/ondemand_metric.go
@@ -116,7 +116,7 @@ func GetMCISOnDemandPacketInfo(nsId string, mcisId string, vmId string, watchTim
 	}
 
 	if sourceAgentIP == "" || len(targetAgentInfo) == 0 {
-		return NetworkPacketsResult{}, http.StatusOK, nil
+		return NetworkPacketsResult{}, http.StatusInternalServerError, errors.New("two or more agents must be installed, and each agent must have a different vm_id")
 	}
 
 	client := http.Client{

--- a/pkg/api/rest/agent/metadata.go
+++ b/pkg/api/rest/agent/metadata.go
@@ -78,7 +78,7 @@ func GetAgentMetadata(c echo.Context) error {
 		if !checkEmptyFormParam(nsId, serviceId, vmId, cspType) {
 			return c.JSON(http.StatusBadRequest, rest.SetMessage("bad request parameter to get mcis agent metadata"))
 		}
-		requestInfo.Mck8sId = serviceId
+		requestInfo.McisId = serviceId
 		requestInfo.VmId = vmId
 		requestInfo.CspType = cspType
 	}


### PR DESCRIPTION
- helm 으로 설치 시 kapacitor 제대로 동작하지 않는 버그 해결: helm template secret.yaml 추가, helm values.yaml 수정
- 이벤트 로그 조회 안되는 버그 해결: cb-store에서 제대로 된 key값을 가져오도록 수정
- 이벤트핸들러 생성 및 업데이트 시, 필요 없는 파라미터 받지 않도록 수정
- mcis ondemand network 2개 이상의 에이전트가 존재하지 않는 경우 오류 메시지 보여주도록 수정
- 에이전트 메타데이터 조회 버그 해결
- 헬름 CB-Dragonfly 버전 업그레이드